### PR TITLE
Traducciones

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "symfony/yaml": "5.4.*",
         "symfonycasts/verify-email-bundle": "^1.12",
         "twig/extra-bundle": "^2.12|^3.0",
+        "twig/intl-extra": "^3.5",
         "twig/twig": "^2.12|^3.0"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f8078e2e93b554f2bd6a41164e41035",
+    "content-hash": "3715b6814c95732cc411348e0405134f",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -8043,6 +8043,75 @@
                 }
             ],
             "time": "2022-01-04T13:58:53+00:00"
+        },
+        {
+            "name": "twig/intl-extra",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/intl-extra.git",
+                "reference": "c3ebfac1624228c0556de57a34af6b7d83a1a408"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/intl-extra/zipball/c3ebfac1624228c0556de57a34af6b7d83a1a408",
+                "reference": "c3ebfac1624228c0556de57a34af6b7d83a1a408",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/intl": "^4.4|^5.0|^6.0",
+                "twig/twig": "^2.7|^3.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Twig\\Extra\\Intl\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "A Twig extension for Intl",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "intl",
+                "twig"
+            ],
+            "support": {
+                "source": "https://github.com/twigphp/intl-extra/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-02-08T07:44:55+00:00"
         },
         {
             "name": "twig/twig",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,7 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
-
+    app.supported_locales: ['en', 'es', 'fr', 'gl']
 services:
     # default configuration for services in *this* file
     _defaults:

--- a/migrations/Version20221218121331.php
+++ b/migrations/Version20221218121331.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20221218121331 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        //Limitaod a 3 caracteres porque refereirmos a cada idioma conforme ISO 639-1 (uno extra para posible migracióna iso 639 -[<=3])
+        $this->addSql("ALTER TABLE usuario ADD locale VARCHAR(3) NOT NULL DEFAULT 'gl'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE usuario DROP locale');
+    }
+}

--- a/src/Controller/InicioController.php
+++ b/src/Controller/InicioController.php
@@ -1,27 +1,31 @@
 <?php
 
 namespace App\Controller;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
-use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class InicioController extends AbstractController
 {
+
+    /**
+     * Solo redirecciona conforme al _locale
+     *
+     * @param Request $request
+     * @param FlashBagInterface $sessionapi
+     * @return Response
+     */
     #[Route('/', name: 'inicio')]
-    public function inicio(FlashBagInterface $sessionapi): Response
+    public function inicioIndex(Request $request, FlashBagInterface $sessionapi): Response
     {
+        $locale = $request->getLocale();
 
-        //$session = $requestStack->getSession();
-        $foo = implode("<br>",$sessionapi->get('success'));
 
-        
-        return $this->render('principal/inicio.html.twig');
-        
-        // new Response(
-        //     "$foo <br/><html><body> Ola Mundo</body></html>"
-        // );
+        return $this->redirectToRoute('inicioLocale', ['_locale' => $locale]);
+
     }
-
 }

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -7,6 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
+#[Route('/{_locale}')]
 class LoginController extends AbstractController
 {
     #[Route('/login', name: 'app_login')]

--- a/src/Controller/PathsController.php
+++ b/src/Controller/PathsController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+#[Route('/{_locale}')]
+class PathsController extends AbstractController
+{
+
+   
+
+    #[Route('/inicio', name: 'inicioLocale')]
+    public function inicioLocale(Request $request, FlashBagInterface $sessionapi): Response
+    {
+
+        $locale = $request->getLocale();
+        //$session = $requestStack->getSession();
+        $foo = implode("<br>",$sessionapi->get('success'));
+        
+        return $this->render('principal/inicio.html.twig');
+        
+        // return new Response(
+        //     "$foo <br/><html><body> Ola Mundo</body></html>"
+        // );
+    }
+
+    #[Route('/proba', name: 'proba')]
+    public function proba(Request $request, FlashBagInterface $sessionapi): Response
+    {
+        
+
+        // dump($requestStack->getSession());
+        // die;
+        $locale = $request->getLocale();
+        //$session = $requestStack->getSession();
+        $foo = implode("<br>",$sessionapi->get('success'));
+
+        
+        return $this->render('principal/inicio.html.twig');
+        
+        // new Response(
+        //     "$foo <br/><html><body> Ola Mundo</body></html>"
+        // );
+    }
+}

--- a/src/Entity/Usuario.php
+++ b/src/Entity/Usuario.php
@@ -32,6 +32,9 @@ class Usuario implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: 'boolean')]
     private $isVerified = false;
 
+    #[ORM\Column(length: 3)]
+    private ?string $locale = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -129,6 +132,18 @@ class Usuario implements UserInterface, PasswordAuthenticatedUserInterface
     public function setIsVerified(bool $isVerified): self
     {
         $this->isVerified = $isVerified;
+
+        return $this;
+    }
+
+    public function getLocale(): ?string
+    {
+        return $this->locale;
+    }
+
+    public function setLocale(string $locale): self
+    {
+        $this->locale = $locale;
 
         return $this;
     }

--- a/src/EventSubscriber/LocaleSubscriber.php
+++ b/src/EventSubscriber/LocaleSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class LocaleSubscriber implements EventSubscriberInterface
+{
+    private $defaultLocale;
+
+    public function __construct(string $defaultLocale = 'en')
+    {
+        $this->defaultLocale = $defaultLocale;
+    }
+
+    public function onKernelRequest(RequestEvent $event)
+    {
+        $request = $event->getRequest();
+        if (!$request->hasPreviousSession()) {
+            return;
+        }
+
+        // try to see if the locale has been set as a _locale routing parameter
+        if ($locale = $request->attributes->get('_locale')) {
+            $request->getSession()->set('_locale', $locale);
+        } else {
+            // if no explicit locale has been set on this request, use one from the session
+            $request->setLocale($request->getSession()->get('_locale', $this->defaultLocale));
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            // must be registered before (i.e. with a higher priority than) the default Locale listener
+            KernelEvents::REQUEST => [['onKernelRequest', 20]],
+        ];
+    }
+}

--- a/src/EventSubscriber/LocaleSubscriber.php
+++ b/src/EventSubscriber/LocaleSubscriber.php
@@ -26,8 +26,22 @@ class LocaleSubscriber implements EventSubscriberInterface
             $request->getSession()->set('_locale', $locale);
         } else {
             // if no explicit locale has been set on this request, use one from the session
-            $request->setLocale($request->getSession()->get('_locale', $this->defaultLocale));
+            $localeSession=$request->getSession()->get('_locale', $this->defaultLocale);
+            $request->setLocale($localeSession);
         }
+        
+        //$this->requestStack->getSession()->set('_locale', $user->getLocale())
+        
+        
+
+        /*
+        // try to see if the locale has been set as a _locale routing parameter
+        if ($locale = $request->attributes->get('_locale')) {
+            $request->getSession()->set('_locale', $locale);
+        } else {
+            // if no explicit locale has been set on this request, use one from the session
+            $request->setLocale($request->getSession()->get('_locale', $this->defaultLocale));
+        }  */
     }
 
     public static function getSubscribedEvents()

--- a/src/EventSubscriber/UserLocaleSubscriber.php
+++ b/src/EventSubscriber/UserLocaleSubscriber.php
@@ -1,0 +1,46 @@
+<?php
+// src/EventSubscriber/UserLocaleSubscriber.php
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+/**
+ * Stores the locale of the user in the session after the
+ * login. This can be used by the LocaleSubscriber afterwards.
+ */
+class UserLocaleSubscriber implements EventSubscriberInterface
+{
+    private $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * Hacemos el locale del usuario sticky en la sesión.
+     * Solo llamado tras hacer login
+     *
+     * @param InteractiveLoginEvent $event
+     * @return void
+     */
+    public function onInteractiveLogin(InteractiveLoginEvent $event)
+    {
+    
+        $user = $event->getAuthenticationToken()->getUser();
+
+        if (null !== $user->getLocale()) {
+            $this->requestStack->getSession()->set('_locale', $user->getLocale());
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            SecurityEvents::INTERACTIVE_LOGIN => 'onInteractiveLogin',
+        ];
+    }
+}

--- a/src/Twig/Extension/TranslationExtension.php
+++ b/src/Twig/Extension/TranslationExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class TranslationExtension extends AbstractExtension
+{
+
+
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('urlremovelocale', [$this, 'removeLocale'],['is_safe' => ['html']]),
+        ];
+    }
+
+    public function removeLocale($value)
+    {
+        // /locale/direcion/url/ --> direccion/url/"
+        $rutaRelativaSinLocale=preg_replace('/^(\/[a-z]{0,}\/)/', '', $value);
+        return $rutaRelativaSinLocale;
+    }
+
+    
+}

--- a/templates/header.html.twig
+++ b/templates/header.html.twig
@@ -1,36 +1,82 @@
 <nav class="navbar navbar-expand-lg bg-light">
   <div class="container-fluid">
-    <a class="navbar-brand" href="#">Navbar</a>
+    <a class="navbar-brand" href="#">Sharify</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
         <li class="nav-item">
-          <a class="nav-link active" aria-current="page" href="#">Home</a>
+          <a class="nav-link active" aria-current="page" href="#">Inicio</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="#">Link</a>
         </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-            Dropdown
-          </a>
-          <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href="#">Action</a></li>
-            <li><a class="dropdown-item" href="#">Another action</a></li>
-            <li><hr class="dropdown-divider"></li>
-            <li><a class="dropdown-item" href="#">Something else here</a></li>
-          </ul>
-        </li>
+        
         <li class="nav-item">
           <a class="nav-link disabled">Disabled</a>
         </li>
+        <li class="nav-item dropdown dropend d-lg-none">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            Idiomas
+          </a>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item " href="#">English</a></li>
+            <li><a class="dropdown-item" href="#">Galego</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="dropdown-item" href="#">Otros</a></li>
+
+            
+          </ul>
+        </li>
+        <li class="nav-item">
+        <div class="btn-group dropend d-lg-none">
+          <button type="button" class="btn btn-secondary">
+            Idioma
+          </button>
+          <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+            <span class="visually-hidden">Idioma</span>
+          </button>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item " href="#">English</a></li>
+            <li><a class="dropdown-item" href="#">Galego</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="dropdown-item" href="#">Otros</a></li>
+          </ul>
+        </div>
+        </li>
       </ul>
-      <form class="d-flex" role="search">
+      
+      {# <form class="d-flex" role="search">
         <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
         <button class="btn btn-outline-success" type="submit">Search</button>
-      </form>
+      </form> #}
     </div>
+    
+  </div>
+  {# <ul class="d-none d-lg-block navbar-nav me-auto mb-2 mb-lg-0">
+    <li class="nav-item dropdown float-lg-end">
+      <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+        Idiomas
+      </a>
+      <ul class="dropdown-menu">
+        <li><a class="dropdown-item" href="#">English</a></li>
+        <li><a class="dropdown-item" href="#">Galego</a></li>
+        <li><hr class="dropdown-divider"></li>
+        <li><a class="dropdown-item" href="#">Otros</a></li>
+      </ul>
+    </li>
+  </ul> #}
+  <div class="btn-group dropstart">
+    <button type="button" class="d-none d-lg-block btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+      Idioma
+    </button>
+    <ul class="dropdown-menu">
+      <li><a class="dropdown-item" href="#">English</a></li>
+      <li><a class="dropdown-item" href="#">Galego</a></li>
+      <li><hr class="dropdown-divider"></li>
+      {# {{ dump(app.request) }} #}
+      <li><a class="dropdown-item" href="#">Otros</a></li>
+    </ul>
   </div>
 </nav>

--- a/templates/header.html.twig
+++ b/templates/header.html.twig
@@ -12,11 +12,14 @@
         <li class="nav-item">
           <a class="nav-link" href="#">Link</a>
         </li>
-        
         <li class="nav-item">
-          <a class="nav-link disabled">Disabled</a>
+          <a class="nav-link active" aria-current="page" href="{{ path('app_login', {_locale:app.request.locale}) }}">{{"Login"|trans}}</a>
         </li>
-        <li class="nav-item dropdown dropend d-lg-none">
+        
+        {# <li class="nav-item">
+          <a class="nav-link disabled">Disabled</a>
+        </li> #}
+        {# <li class="nav-item dropdown dropend d-lg-none">
           <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             Idiomas
           </a>
@@ -28,7 +31,7 @@
 
             
           </ul>
-        </li>
+        </li> #}
         <li class="nav-item">
         <div class="btn-group dropend d-lg-none">
           <button type="button" class="btn btn-secondary">

--- a/templates/header.html.twig
+++ b/templates/header.html.twig
@@ -38,8 +38,8 @@
             <span class="visually-hidden">Idioma</span>
           </button>
           <ul class="dropdown-menu">
-            <li><a class="dropdown-item " href="#">English</a></li>
-            <li><a class="dropdown-item" href="#">Galego</a></li>
+            <li><a class="dropdown-item" href="/en/{{app.request.pathInfo|urlremovelocale}} "></a>English</li>      
+      <li><a class="dropdown-item" href="/gl/{{app.request.pathInfo|urlremovelocale}} ">Galego</a></li>
             <li><hr class="dropdown-divider"></li>
             <li><a class="dropdown-item" href="#">Otros</a></li>
           </ul>
@@ -72,10 +72,9 @@
       Idioma
     </button>
     <ul class="dropdown-menu">
-      <li><a class="dropdown-item" href="#">English</a></li>
-      <li><a class="dropdown-item" href="#">Galego</a></li>
+      <li><a class="dropdown-item" href="/en/{{app.request.pathInfo|urlremovelocale}} ">English</a></li>      
+      <li><a class="dropdown-item" href="/gl/{{app.request.pathInfo|urlremovelocale}} ">Galego</a></li>
       <li><hr class="dropdown-divider"></li>
-      {# {{ dump(app.request) }} #}
       <li><a class="dropdown-item" href="#">Otros</a></li>
     </ul>
   </div>

--- a/templates/principal/inicio.html.twig
+++ b/templates/principal/inicio.html.twig
@@ -3,5 +3,6 @@
 {% block body %}
 
 <div> {{"Hello"|trans}}</div>
+{{ app.request.locale|locale_name(app.request.locale) }}
 
 {% endblock %}

--- a/templates/principal/inicio.html.twig
+++ b/templates/principal/inicio.html.twig
@@ -3,6 +3,4 @@
 {% block body %}
 
 <div> {{"Hello"|trans}}</div>
-{{ app.request.locale|locale_name(app.request.locale) }}
-
 {% endblock %}

--- a/templates/principal/inicio.html.twig
+++ b/templates/principal/inicio.html.twig
@@ -2,6 +2,6 @@
 
 {% block body %}
 
-<div> Ola Mundo</div>
+<div> {{"Hello"|trans}}</div>
 
 {% endblock %}

--- a/translations/messages.gl.yaml
+++ b/translations/messages.gl.yaml
@@ -2,3 +2,4 @@
 #   world: Ola Mundo!
 
 Hello: Ola
+Login: Iniciar Sesión

--- a/translations/messages.gl.yaml
+++ b/translations/messages.gl.yaml
@@ -1,0 +1,4 @@
+# hello:
+#   world: Ola Mundo!
+
+Hello: Ola


### PR DESCRIPTION
Añade el esquema básicos de traducciones, permite leer el locale de base de datos (según usuario), cambiar el idioma en la sesión y hace las urls "locale dependientes" (path(...), {_locale}.
Este último cambio de "path" en twig va a ser mejor crear una extesión para el mismo, dado el alto nivel de repetición que habrá de este tipo de URLs